### PR TITLE
SJ-17 Staff Change Family Password

### DIFF
--- a/database/dbFamily.php
+++ b/database/dbFamily.php
@@ -334,7 +334,7 @@ function getChildren($family_id){
 
 function change_family_password($id, $newPass) {
         $con=connect();
-        $query = 'UPDATE dbFamily SET password = "' . $newPass . '" WHERE email = "' . $id . '"';
+        $query = 'UPDATE dbFamily SET password = "' . $newPass . '" WHERE id = "' . $id . '"';
         $result = mysqli_query($con, $query);
         mysqli_close($con);
         return $result;

--- a/familyView.php
+++ b/familyView.php
@@ -58,6 +58,11 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
 
         <div id="view-family" style="margin-left: 20px; margin-right: 20px">
         <main class="general">
+            <?php
+                if (isset($_GET['pcSuccess'])) {
+                    echo '<div class="happy-toast" style="text-align: center;">Password changed successfully!</div>';
+                }
+            ?>
             <fieldset>
                     <legend>General Information</legend>
                     <label>Account ID</label>
@@ -164,6 +169,9 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
         <?php endif?>
         <?php if($accessLevel > 1): ?> <!--Option for staff to fill a form out for family-->
         <a class="button edit" href="fillForm.php?id=<?php echo $family->getId(); ?>" style="margin-top: .5rem;">Fill Form</a>   
+        <?php endif?>
+        <?php if($accessLevel > 1): ?> <!--Option for staff to fill a form out for family-->
+        <a class="button edit" href="forgotPassword.php?id=<?php echo $family->getId(); ?>" style="margin-top: .5rem;">Change Password</a>   
         <?php endif?>
         <!-- Cancel Buttons -->
         <?php if($_SESSION['access_level'] == 1): ?>

--- a/forgotPassword.php
+++ b/forgotPassword.php
@@ -11,9 +11,11 @@
     $accessLevel = 0;
     $userID = null;
 
-    // If familyEmail and familyVerified session variables are set, get email and continue
-    if (isset($_SESSION['familyEmail']) && isset($_SESSION['familyVerified'])) {
-        $userID = $_SESSION['familyEmail'];
+    // If familyID and familyVerified session variables are set, get id and continue
+    if (isset($_SESSION['familyID']) && isset($_SESSION['familyVerified'])) {
+        $userID = $_SESSION['familyID'];
+    } else if (isset($_GET['id']) && (isset($_SESSION['access_level']) && $_SESSION['access_level'] >= 2)) {
+        $userID = $_GET['id'];
     } else {
         // Else go back to login page
         header('Location: login.php');
@@ -28,9 +30,15 @@
 
         $newPassword = $_POST['new-password'];
         $hash = password_hash($newPassword, PASSWORD_BCRYPT);
+        echo $userID;
         change_family_password($userID, $hash);
-        header('Location: index.php?pcSuccess');
-        die();
+        if (isset($_SESSION['access_level']) && $_SESSION['access_level'] >= 2) {
+            header('Location: familyView.php?pcSuccess&id=' . $_GET['id']);
+            die();
+        } else {
+            header('Location: index.php?pcSuccess');
+            die();
+        }
     }
 ?>
 <!DOCTYPE html>
@@ -50,6 +58,11 @@
                 <input type="password" id="new-password-reenter" placeholder="Re-enter new password" required>
                 <p id="password-match-error" class="error hidden">Passwords must match!</p>
                 <input type="submit" id="submit" name="submit" value="Change Password">
+                <?php
+                    if (isset($_GET['id']) && (isset($_SESSION['access_level']) && $_SESSION['access_level'] >= 2)) {
+                        echo '<a class="button cancel button_stlye" href="familyView.php?id=' . $_GET['id'] . '"  style="margin-top: 1rem;">Return to Family View</a>';
+                    }
+                ?>
             </form>
         </main>
     </body>

--- a/forgotPassword.php
+++ b/forgotPassword.php
@@ -32,10 +32,12 @@
         $hash = password_hash($newPassword, PASSWORD_BCRYPT);
         echo $userID;
         change_family_password($userID, $hash);
+        // If logged in as staff, go to family view page
         if (isset($_SESSION['access_level']) && $_SESSION['access_level'] >= 2) {
             header('Location: familyView.php?pcSuccess&id=' . $_GET['id']);
             die();
         } else {
+            // Else, go to index page
             header('Location: index.php?pcSuccess');
             die();
         }
@@ -59,6 +61,7 @@
                 <p id="password-match-error" class="error hidden">Passwords must match!</p>
                 <input type="submit" id="submit" name="submit" value="Change Password">
                 <?php
+                    // Show an extra button that takes the user to the family view page if they are logged in as staff
                     if (isset($_GET['id']) && (isset($_SESSION['access_level']) && $_SESSION['access_level'] >= 2)) {
                         echo '<a class="button cancel button_stlye" href="familyView.php?id=' . $_GET['id'] . '"  style="margin-top: 1rem;">Return to Family View</a>';
                     }

--- a/header.php
+++ b/header.php
@@ -75,6 +75,7 @@
         $permission_array['completedforms.php'] = 1;
         $permission_array['holidaymealbagcomplete.php'] = 1;
         $permission_array['addchild.php'] = 1;
+        $permission_array['forgotpassword.php'] = 1;
         //pages only staff can view
         $permission_array['personsearch.php'] = 2;
         $permission_array['personedit.php'] = 0; // changed to 0 so that applicants can apply

--- a/securityQuestions.php
+++ b/securityQuestions.php
@@ -9,8 +9,8 @@
 
     // Get user security question
     $question = null;
-    if (isset($_SESSION['familyEmail'])) {
-        $user = retrieve_family_by_email($_SESSION['familyEmail']);
+    if (isset($_SESSION['familyID'])) {
+        $user = retrieve_family_by_id($_SESSION['familyID']);
         // Variable to hold security question
         $question = $user->getSecurityQuestion();
     } else {

--- a/verifyEmail.php
+++ b/verifyEmail.php
@@ -16,8 +16,8 @@
             $email = strtolower($args['email']);
             $user = retrieve_family_by_email($email);
             if ($user) {
-                // Set familyEmail session variable to hold the email of the account
-                $_SESSION['familyEmail'] = $user->getEmail();
+                // Set familyID session variable to hold the id of the account
+                $_SESSION['familyID'] = $user->getID();
                 header('Location: securityQuestions.php');
                 die();
             }


### PR DESCRIPTION
Added functionality for staff to change the password of a family account. To get to the change password page, go to family search, pick a family, and press the change password button at the bottom of the familyView.php  page. Once a staff changes the password, it should take them back to the familyView.php page with a message telling them the password change was successful.

Also changed the change_family_password() password function in dbFamily.php to take the family id instead of email.

Below is an image of the family view page with the password change success message. The change password button is at the bottom.

![Screenshot 2024-11-24 at 00-03-13 Stafford Junction View Account](https://github.com/user-attachments/assets/a47432a4-b2fb-4d16-80f0-8f7d82ae45c7)
