### PR TITLE
Removed header.php from childAccount.php bc siteground bug

### DIFF
--- a/childAccount.php
+++ b/childAccount.php
@@ -42,7 +42,7 @@ $child = retrieve_child_by_id($_GET['id']);
     </head>
     <body>
         <?php 
-            require_once('header.php');
+            //require_once('header.php');
             require_once('include/output.php');
         ?>
         <h1>Account Page for <?php echo $child->getFirstName() . " " . $child->getLastName() ?></h1>
@@ -75,11 +75,11 @@ $child = retrieve_child_by_id($_GET['id']);
             echo '<p>' . $child->getNotes() . '</p>';
             echo '<label>Enrolled Programs</label>';
 
-            if(isBrainBuildersRegistrationComplete($_GET['id'])){
+            if(isBrainBuildersRegistrationComplete($_GET['id'] ?? $child->getID())){
                 echo "Brain Builders" . "<br>";
             }
 
-            if(isSummerJunctionFormComplete($_GET['id'])){
+            if(isSummerJunctionFormComplete($_GET['id'] ?? $child->getID())){
                 echo "Summer Junction" . "<br>";
             }
 

--- a/header.php
+++ b/header.php
@@ -35,7 +35,6 @@
             </ul>
         </nav>';
         //      <li><a href="register.php">Register</a></li>     was at line 35
-
     } else if ($_SESSION['logged_in']) {
 
         /*         * Set our permission array.


### PR DESCRIPTION
More small fixes, had to get rid of header.php line in childAccount.php because for some reason site ground doesn't see it and instead just displays log in at the top of the page. If the user clicked on that link, they'd be directed to the admin page 